### PR TITLE
fix: ignore private repositories

### DIFF
--- a/github-app.js
+++ b/github-app.js
@@ -5,7 +5,7 @@ const GOOD_FIRST_REGEX = /^good\sfirst\sissue$/i;
  * @param {import("@octokit/app").App} app
  */
 export default async function githubApp(env, app) {
-  app.log.info('App loaded');
+  app.log.info("App loaded");
 
   app.webhooks.onAny(async ({ name, payload }) => {
     const eventNameWithAction = payload.action ? `${name}.${payload.action}` : name;
@@ -13,24 +13,27 @@ export default async function githubApp(env, app) {
     app.log.info(`Event received: ${eventNameWithAction}`);
   });
 
-  app.webhooks.on('issues.labeled', async (context) => {
-    const { name } = context.payload.label;
+  app.webhooks.on("issues.labeled", async (context) => {
+    // ignore private repositories
+    if (context.payload.repository.private) return;
 
+    // ignore if label is not "good first issue"
+    const { name } = context.payload.label;
     if (!GOOD_FIRST_REGEX.test(name)) return;
 
     // send message to discord
     const discordWebhookUrl = env.DISCORD_WEBHOOKS_URL;
     const params = {
-      username: 'GFI-Catsup [beta]',
-      avatar_url: 'https://github.com/open-sauced/assets/blob/master/logo.png?raw=true',
+      username: "GFI-Catsup [beta]",
+      avatar_url: "https://github.com/open-sauced/assets/blob/master/logo.png?raw=true",
       content: `New good first issue: ${context.payload.issue.html_url}`,
     };
 
     // send post request using fetch to webhook
     await fetch(discordWebhookUrl, {
-      method: 'POST',
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
       },
       body: JSON.stringify(params),
     });

--- a/github-app.js
+++ b/github-app.js
@@ -5,7 +5,7 @@ const GOOD_FIRST_REGEX = /^good\sfirst\sissue$/i;
  * @param {import("@octokit/app").App} app
  */
 export default async function githubApp(env, app) {
-  app.log.info("App loaded");
+  app.log.info('App loaded');
 
   app.webhooks.onAny(async ({ name, payload }) => {
     const eventNameWithAction = payload.action ? `${name}.${payload.action}` : name;
@@ -13,7 +13,7 @@ export default async function githubApp(env, app) {
     app.log.info(`Event received: ${eventNameWithAction}`);
   });
 
-  app.webhooks.on("issues.labeled", async (context) => {
+  app.webhooks.on('issues.labeled', async (context) => {
     // ignore private repositories
     if (context.payload.repository.private) return;
 
@@ -24,16 +24,16 @@ export default async function githubApp(env, app) {
     // send message to discord
     const discordWebhookUrl = env.DISCORD_WEBHOOKS_URL;
     const params = {
-      username: "GFI-Catsup [beta]",
-      avatar_url: "https://github.com/open-sauced/assets/blob/master/logo.png?raw=true",
+      username: 'GFI-Catsup [beta]',
+      avatar_url: 'https://github.com/open-sauced/assets/blob/master/logo.png?raw=true',
       content: `New good first issue: ${context.payload.issue.html_url}`,
     };
 
     // send post request using fetch to webhook
     await fetch(discordWebhookUrl, {
-      method: "POST",
+      method: 'POST',
       headers: {
-        "Content-Type": "application/json",
+        'Content-Type': 'application/json',
       },
       body: JSON.stringify(params),
     });


### PR DESCRIPTION
prevents to send messages about issues that are in private repos to discord:
<img width="736" alt="image" src="https://github.com/open-sauced/catsup/assets/39992/3328dcba-9c40-4ed2-ac54-630602cccc2b">
